### PR TITLE
fix: Supabase 실패해도 정상 작동하도록 개선

### DIFF
--- a/src/pages/_components/AttendanceChangeForm.tsx
+++ b/src/pages/_components/AttendanceChangeForm.tsx
@@ -88,7 +88,14 @@ const AttendanceChangeForm = () => {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     updateForm(formData);
-    await addClassRecord(formData.campus, String(formData.classNumber));
+
+    // Supabase 실패해도 계속 진행
+    try {
+      await addClassRecord(formData.campus, String(formData.classNumber));
+    } catch (error) {
+      console.warn("통계 기록 실패 :", error);
+    }
+
     router.push("/preview2");
   };
 

--- a/src/pages/_components/AttendanceConfirmForm.tsx
+++ b/src/pages/_components/AttendanceConfirmForm.tsx
@@ -181,10 +181,16 @@ const AbsenceForm = () => {
       };
 
       setConfirmForm(transformedData);
-      await addClassRecord(
-        transformedData.campus,
-        String(transformedData.class)
-      );
+
+      // Supabase 실패해도 계속 진행
+      try {
+        await addClassRecord(
+          transformedData.campus,
+          String(transformedData.class)
+        );
+      } catch (error) {
+        console.warn("통계 기록 실패:", error);
+      }
 
       router.push("/preview");
     } catch (error) {


### PR DESCRIPTION
## 문제점

- DNS 에러 DNS_PROBE_FINISHED_NXDOMAIN가 발생함. Supabase 프로젝트에 문제가 발생한걸로 예상됨.
- 폼 제출 시 Supabase 호출 실패로 미리보기 페이지로 이동하지 못함.
- 소명 확인서 양식 제출시 Supabase 호출 실패로 미리보기 생성하지 못함.

## 해결방법
- 두 개의 폼 컴포넌트에서 Supabase 호출을 try-catch로 감싸 에러 무시
- 통계 기록 실패 시에도 정상적으로 페이지 이동 및 PDF 생성 가능하도록 개선

## 변경사항
  - `src/pages/_components/AttendanceChangeForm.tsx`: Supabase 에러 처리 추가
  - `src/pages/_components/AttendanceConfirmForm.tsx`: Supabase 에러 처리 추가

## 테스트
- [x] 소명확인서  → 양식미리보기 페이지 이동 확인
- [x] 변경요청서  → 양식미리보기 페이지 이동 확인
- [x] 소명확인서, 변경요청서 PDF 다운로드 정상 작동 확인
- [x]  콘솔에서 Supabase 경고 메시지 확인